### PR TITLE
Fix V575 warning from PVS-Studio Static Analyzer

### DIFF
--- a/source/cpp/custom_liblinear_wrapper/LibLinear/train.c
+++ b/source/cpp/custom_liblinear_wrapper/LibLinear/train.c
@@ -75,7 +75,8 @@ static char* readline(FILE *input)
 	while(strrchr(line,'\n') == NULL)
 	{
 		max_line_len *= 2;
-		line = (char *) realloc(line,max_line_len);
+                char *t = (char *)realloc(line,max_line_len);
+                if (t) line = t;
 		len = (int) strlen(line);
 		if(fgets(line+len,max_line_len-len,input) == NULL)
 			break;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
The potential null pointer is passed into 'strlen' function.
Inspect the first argument.