### PR TITLE
Fix V701 warning from PVS-Studio Static Analyzer

### DIFF
--- a/source/cpp/custom_liblinear_wrapper/LibLinear/train.c
+++ b/source/cpp/custom_liblinear_wrapper/LibLinear/train.c
@@ -221,7 +221,10 @@ void parse_command_line(int argc, char **argv, char *input_file_name, char *mode
 
 			case 'w':
 				++param.nr_weight;
-				param.weight_label = (int *) realloc(param.weight_label,sizeof(int)*param.nr_weight);
+                                {
+                                    int *t = (int *) realloc(param.weight_label,sizeof(int)*param.nr_weight);
+                                    if (t) param.weight_label = t;
+                                }
 				param.weight = (double *) realloc(param.weight,sizeof(double)*param.nr_weight);
 				param.weight_label[param.nr_weight-1] = atoi(&argv[i-1][2]);
 				param.weight[param.nr_weight-1] = atof(argv[i]);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
realloc() possible leak: when realloc() fails in allocating memory,
original pointer 'param.weight_label' is lost.
Consider assigning realloc() to a temporary pointer.