### PR TITLE
Fix V575 warning from PVS-Studio Static Analyzer

### DIFF
--- a/source/cpp/custom_liblinear_wrapper/LibLinear/linear.cpp
+++ b/source/cpp/custom_liblinear_wrapper/LibLinear/linear.cpp
@@ -214,6 +214,7 @@ protected:
 };
 
 l2r_l2_svc_fun::l2r_l2_svc_fun(const problem *prob, double *C)
+    :sizeI(0)
 {
 	int l=prob->l;
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
Not all members of a class are initialized inside the constructor.
Consider inspecting: sizeI.