### PR TITLE
Fix V611 warning from PVS-Studio Static Analyzer

### DIFF
--- a/source/cpp/custom_liblinear_wrapper/LibLinear/linear.cpp
+++ b/source/cpp/custom_liblinear_wrapper/LibLinear/linear.cpp
@@ -2190,7 +2190,7 @@ static void train_one(const problem *prob, const parameter *param, double *w, do
 			tron_obj.set_print_string(liblinear_print_string);
 			tron_obj.tron(w);
 			delete fun_obj;
-			delete C;
+                        delete [] C;
 			break;
 		}
 		case L2R_L2LOSS_SVC:
@@ -2208,7 +2208,7 @@ static void train_one(const problem *prob, const parameter *param, double *w, do
 			tron_obj.set_print_string(liblinear_print_string);
 			tron_obj.tron(w);
 			delete fun_obj;
-			delete C;
+                        delete [] C;
 			break;
 		}
 		case L2R_L2LOSS_SVC_DUAL:
@@ -2253,7 +2253,7 @@ static void train_one(const problem *prob, const parameter *param, double *w, do
 			tron_obj.set_print_string(liblinear_print_string);
 			tron_obj.tron(w);
 			delete fun_obj;
-			delete C;
+                        delete [] C;
 			break;
 
 		}


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
The memory was allocated using 'new T[]' operator but was released
using the 'delete' operator. Consider inspecting this code.